### PR TITLE
Add option to customize migration table

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ end
 ```
 
 DynamoDB::Migration will detect this class and execute once against your
-DynamoDB instance. It will record the execution in a table called `migrations`
-which it creates and maintains internally.
+DynamoDB instance. It will record the execution in a table specified by `DynamoDB::Migration.migration_table_name` (`migrations` by default) which it creates and maintains internally.
 
 ## Development
 

--- a/lib/dynamodb/migration.rb
+++ b/lib/dynamodb/migration.rb
@@ -5,6 +5,16 @@ require "dynamodb/migration/unit"
 module DynamoDB
   module Migration
     class << self
+      DEFAULT_MIGRATION_TABLE_NAME = 'migrations'
+
+      def migration_table_name
+        @migration_table_name || DEFAULT_MIGRATION_TABLE_NAME
+      end
+
+      def migration_table_name=(name)
+        @migration_table_name = name
+      end
+
       def registered(app)
         options = {
           client: app.dynamodb_client,

--- a/lib/dynamodb/migration.rb
+++ b/lib/dynamodb/migration.rb
@@ -4,20 +4,22 @@ require "dynamodb/migration/unit"
 
 module DynamoDB
   module Migration
-    def self.registered(app)
-      options = {
-        client: app.dynamodb_client,
-        path:   app.settings.migrations_path,
-      }
-      run_all_migrations(options)
-    end
-
-    def self.run_all_migrations(options)
-      Dir.glob("#{options[:path]}/**/*.rb").each do |file|
-        require file
+    class << self
+      def registered(app)
+        options = {
+          client: app.dynamodb_client,
+          path:   app.settings.migrations_path,
+        }
+        run_all_migrations(options)
       end
-      Execute.new(options[:client])
-             .update_all
+
+      def run_all_migrations(options)
+        Dir.glob("#{options[:path]}/**/*.rb").each do |file|
+          require file
+        end
+        Execute.new(options[:client])
+               .update_all
+      end
     end
   end
 end

--- a/lib/dynamodb/migration/execute.rb
+++ b/lib/dynamodb/migration/execute.rb
@@ -30,7 +30,7 @@ module DynamoDB
 
       def record_failed_migration(clazz)
         client.delete_item({
-          table_name: "migrations",
+          table_name: Migration.migration_table_name,
           key: {
             "file" => clazz_filename(clazz),
           },
@@ -43,7 +43,7 @@ module DynamoDB
 
       def record_start_migration(clazz)
         client.put_item({
-          table_name: "migrations",
+          table_name: Migration.migration_table_name,
           item: {
             "file" => clazz_filename(clazz),
             "executed_at" => Time.now.iso8601,
@@ -57,7 +57,7 @@ module DynamoDB
 
       def record_successful_migration(clazz)
         client.update_item({
-          table_name: "migrations",
+          table_name: Migration.migration_table_name,
           key: {
             "file" => clazz_filename(clazz),
           },
@@ -87,7 +87,7 @@ module DynamoDB
 
       def migration_executed?(clazz)
         client.get_item({
-          table_name: "migrations",
+          table_name: Migration.migration_table_name,
           key: {
             "file" => clazz_filename(clazz),
           },
@@ -98,7 +98,7 @@ module DynamoDB
 
       def ensure_migrations_table_exists
         client.create_table(
-          table_name: "migrations",
+          table_name: Migration.migration_table_name,
           attribute_definitions: [
             {
               attribute_name: "file",
@@ -119,7 +119,7 @@ module DynamoDB
             stream_enabled: true,
             stream_view_type: "NEW_AND_OLD_IMAGES",
           },
-        ) unless table_exists?(client, 'migrations')
+        ) unless table_exists?(client, Migration.migration_table_name)
       end
 
       def table_exists?(client, table_name)


### PR DESCRIPTION
@henrylawson, please review.

Rationale:
There is sometimes a desire to have the ability to customize the `migrations` table name. This can be for environmental separation `staging_migrations` vs `production_migrations` or other reasons. We still maintain the default of `migrations` for backward compatibility.
